### PR TITLE
feat : 조회수 기능 추가 및 웹툰 열람 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compileOnly 'org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/webtoon/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/webtoon/global/exception/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
     NOT_FOUND_WEBTOON(HttpStatus.BAD_REQUEST,"일치하는 웹툰이 없습니다."),
     FAIL_TO_UPLOAD_FILE(HttpStatus.BAD_REQUEST,"파일 업로드에 실패했습니다."),
     DENIED_ACCESS_PERMISSION(HttpStatus.BAD_REQUEST,"접근이 거부되었습니다."),
-    EXISTS_WEBTOONNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 웹툰 이름입니다.");
+    EXISTS_WEBTOONNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 웹툰 이름입니다."),
+    NO_EXISTS_WEBTOONCHAPTER(HttpStatus.BAD_REQUEST,"존재하지 않는 웹툰 챕터입니다.");
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/src/main/java/com/example/webtoon/global/redis/RedisConfig.java
+++ b/src/main/java/com/example/webtoon/global/redis/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.example.webtoon.global.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/webtoon/global/redis/RedisDao.java
+++ b/src/main/java/com/example/webtoon/global/redis/RedisDao.java
@@ -1,0 +1,43 @@
+package com.example.webtoon.global.redis;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisDao {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void setValues(String key, String data) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data);
+    }
+
+    public void setValuesList(String key, String data) {
+        redisTemplate.opsForList().rightPushAll(key,data);
+    }
+
+    public List<String> getValuesList(String key) {
+        Long len = redisTemplate.opsForList().size(key);
+        return len == 0 ? new ArrayList<>() : redisTemplate.opsForList().range(key, 0, len-1);
+    }
+
+    public void setValues(String key, String data, Duration duration) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    public String getValues(String key) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/example/webtoon/global/redis/RestTemplateConfig.java
+++ b/src/main/java/com/example/webtoon/global/redis/RestTemplateConfig.java
@@ -1,0 +1,26 @@
+package com.example.webtoon.global.redis;
+
+import java.nio.charset.StandardCharsets;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+            .requestFactory(
+                () -> new BufferingClientHttpRequestFactory(
+                    new SimpleClientHttpRequestFactory()
+                )
+            ).additionalMessageConverters(
+                new StringHttpMessageConverter(
+                    StandardCharsets.UTF_8
+                )).build();
+    }
+}

--- a/src/main/java/com/example/webtoon/user/security/SecurityConfig.java
+++ b/src/main/java/com/example/webtoon/user/security/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .authorizeHttpRequests()
-            .antMatchers("/**/auth/**").permitAll()
+            .antMatchers("/**/auth/**","/**/webtoon/**").permitAll()
             .anyRequest().authenticated()
             .and()
             .addFilterBefore(this.authenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/webtoon/webtoon/controller/WebtoonController.java
+++ b/src/main/java/com/example/webtoon/webtoon/controller/WebtoonController.java
@@ -1,8 +1,13 @@
 package com.example.webtoon.webtoon.controller;
 
+import com.example.webtoon.webtoon.domain.dto.WebtoonChapterInfo;
 import com.example.webtoon.webtoon.domain.dto.WebtoonDto;
+import com.example.webtoon.webtoon.domain.dto.WebtoonInfo;
 import com.example.webtoon.webtoon.domain.model.Webtoon;
+import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
 import com.example.webtoon.webtoon.service.WebtoonService;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -25,5 +30,27 @@ public class WebtoonController {
     public ResponseEntity<WebtoonDto> searchWebtoon(@RequestParam Long id){
         Webtoon webtoon = webtoonService.getWebtoon(id);
         return ResponseEntity.ok(WebtoonDto.from(webtoon));
+    }
+
+    @Transactional
+    @GetMapping("/index")
+    public ResponseEntity<List<WebtoonInfo>> getAllWebtoons(){
+        List<WebtoonInfo> allWebtoons = webtoonService.getAllWebtoons();
+        return ResponseEntity.ok(allWebtoons);
+    }
+
+    @Transactional
+    @GetMapping("/list")
+    public ResponseEntity<List<WebtoonChapterInfo>> getWebtoonChapters(@RequestParam Long webtoonId){
+        List<WebtoonChapterInfo> webtoonChapters = webtoonService.getWebtoonChapters(webtoonId);
+        return ResponseEntity.ok(webtoonChapters);
+    }
+
+    @Transactional
+    @GetMapping("/detail")
+    public ResponseEntity<WebtoonChapterInfo> getWebtoon(HttpServletRequest request, @RequestParam Long id){
+        String ipAddress = request.getRemoteAddr();
+        WebtoonChapterInfo webtoonChapter = webtoonService.getWebtoonChapter(id, ipAddress);
+        return ResponseEntity.ok(webtoonChapter);
     }
 }

--- a/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonChapterInfo.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonChapterInfo.java
@@ -1,0 +1,17 @@
+package com.example.webtoon.webtoon.domain.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class WebtoonChapterInfo {
+    private Long id;
+    private String webtoonName;
+    private String chapterName;
+    private Integer chapterCount;
+    private List<String> webtoonImgs;
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonInfo.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonInfo.java
@@ -1,0 +1,18 @@
+package com.example.webtoon.webtoon.domain.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class WebtoonInfo {
+    private Long id;
+    private String author;
+    private List<String> hashtags;
+    private String uploadDay;
+    private Long viewCount;
+    private Double starScore;
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/model/WebtoonChapter.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/model/WebtoonChapter.java
@@ -3,6 +3,7 @@ package com.example.webtoon.webtoon.domain.model;
 import com.example.webtoon.global.domain.BaseEntity;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -34,4 +35,8 @@ public class WebtoonChapter extends BaseEntity {
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "WEBTOONCHAPTER_ID")
     private List<WebtoonImg> webtoonImgs = new ArrayList<>();
+
+    public List<String> getWebtoonImgAsStringList(){
+        return webtoonImgs.stream().map(WebtoonImg::getImgUrl).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/example/webtoon/webtoon/domain/model/WebtoonImg.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/model/WebtoonImg.java
@@ -17,6 +17,8 @@ public class WebtoonImg extends BaseEntity {
     private Long id;
     private String imgUrl;
 
+    public String getImgUrl(){return imgUrl;};
+
     private WebtoonImg(String url){
         this.imgUrl = url;
     }

--- a/src/main/java/com/example/webtoon/webtoon/domain/repository/WebtoonChapterRepository.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/repository/WebtoonChapterRepository.java
@@ -2,8 +2,10 @@ package com.example.webtoon.webtoon.domain.repository;
 
 import com.example.webtoon.webtoon.domain.model.Webtoon;
 import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WebtoonChapterRepository extends JpaRepository<WebtoonChapter,Long> {
     Integer countByWebtoon(Webtoon webtoon);
+    List<WebtoonChapter> findAllByWebtoon(Webtoon webtoon);
 }

--- a/src/main/java/com/example/webtoon/webtoon/domain/repository/WebtoonRepository.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/repository/WebtoonRepository.java
@@ -1,6 +1,7 @@
 package com.example.webtoon.webtoon.domain.repository;
 
 import com.example.webtoon.webtoon.domain.model.Webtoon;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/example/webtoon/webtoon/service/WebtoonManageService.java
+++ b/src/main/java/com/example/webtoon/webtoon/service/WebtoonManageService.java
@@ -4,6 +4,7 @@ import com.example.webtoon.global.exception.ErrorCode;
 import com.example.webtoon.global.exception.GlobalException;
 import com.example.webtoon.global.fileUpload.StoreFileClient;
 import com.example.webtoon.global.fileUpload.UploadFile;
+import com.example.webtoon.global.redis.RedisDao;
 import com.example.webtoon.user.domain.model.User;
 import com.example.webtoon.user.domain.repository.UserRepository;
 import com.example.webtoon.webtoon.domain.dto.CreateWebtoonRequest;
@@ -30,6 +31,7 @@ public class WebtoonManageService {
     private final WebtoonRepository webtoonRepository;
     private final WebtoonChapterRepository webtoonChapterRepository;
     private final StoreFileClient storeFileClient;
+    private final RedisDao redisDao;
 
     @Transactional
     public Webtoon createWebtoon(CreateWebtoonRequest request, String email){
@@ -42,7 +44,7 @@ public class WebtoonManageService {
         Set<WebtoonHashtag> hashtags = request.getHashtags().stream()
             .map(WebtoonHashtag::of)
             .collect(Collectors.toSet());
-        return webtoonRepository.save(
+        Webtoon webtoon = webtoonRepository.save(
             Webtoon.builder()
                 .author(user)
                 .hashtags(hashtags)
@@ -51,6 +53,9 @@ public class WebtoonManageService {
                 .viewCount(0L)
                 .starScore(0.0)
                 .build());
+        String redisKey = String.valueOf(webtoon.getId());
+        redisDao.setValues(redisKey, "0");
+        return webtoon;
     }
 
     @Transactional

--- a/src/main/java/com/example/webtoon/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/example/webtoon/webtoon/service/WebtoonService.java
@@ -2,8 +2,15 @@ package com.example.webtoon.webtoon.service;
 
 import com.example.webtoon.global.exception.ErrorCode;
 import com.example.webtoon.global.exception.GlobalException;
+import com.example.webtoon.global.redis.RedisDao;
+import com.example.webtoon.webtoon.domain.dto.WebtoonChapterInfo;
+import com.example.webtoon.webtoon.domain.dto.WebtoonInfo;
 import com.example.webtoon.webtoon.domain.model.Webtoon;
+import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
+import com.example.webtoon.webtoon.domain.repository.WebtoonChapterRepository;
 import com.example.webtoon.webtoon.domain.repository.WebtoonRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,11 +20,69 @@ import org.springframework.transaction.annotation.Transactional;
 public class WebtoonService {
 
     private final WebtoonRepository webtoonRepository;
+    private final WebtoonChapterRepository webtoonChapterRepository;
+    private final RedisDao redisDao;
 
     @Transactional
     public Webtoon getWebtoon(Long id){
         Webtoon webtoon =  this.webtoonRepository.findById(id)
             .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_WEBTOON));
         return webtoon;
+    }
+
+    public List<WebtoonInfo> getAllWebtoons(){
+        List<Webtoon> webtoonList = this.webtoonRepository.findAll();
+        List<WebtoonInfo> webtoonInfoList = new ArrayList<>();
+        for(Webtoon w : webtoonList){
+            WebtoonInfo webtoonInfo = WebtoonInfo.builder()
+                .id(w.getId())
+                .author(w.getAuthor().getNickname())
+                .hashtags(w.getHashtagsAsStringList())
+                .viewCount(w.getViewCount())
+                .starScore(w.getStarScore())
+                .build();
+            webtoonInfoList.add(webtoonInfo);
+        }
+        return webtoonInfoList;
+    }
+
+    public List<WebtoonChapterInfo> getWebtoonChapters(Long webtoonId){
+        Webtoon webtoon =  this.webtoonRepository.findById(webtoonId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_WEBTOON));
+        List<WebtoonChapter> chapterList = this.webtoonChapterRepository.findAllByWebtoon(webtoon);
+        List<WebtoonChapterInfo> webtoonChapterInfoList = new ArrayList<>();
+        for(WebtoonChapter c : chapterList){
+            WebtoonChapterInfo chapterInfo = webtoonChapterToWebtoonChapterInfo(c);
+            webtoonChapterInfoList.add(chapterInfo);
+        }
+        return webtoonChapterInfoList;
+    }
+
+    public WebtoonChapterInfo getWebtoonChapter(Long chapterId, String ipAddress){
+        WebtoonChapter webtoonChapter = this.webtoonChapterRepository.findById(chapterId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NO_EXISTS_WEBTOONCHAPTER));
+
+        String redisKey = String.valueOf(webtoonChapter.getWebtoon().getId());
+        String values = redisDao.getValues(redisKey);
+        if(!redisDao.getValuesList(ipAddress).contains(redisKey)){
+            Long views = Long.parseLong(values);
+            redisDao.setValuesList(ipAddress, redisKey);
+            views += 1;
+            redisDao.setValues(redisKey, String.valueOf(views));
+        }
+        WebtoonChapterInfo chapterInfo = webtoonChapterToWebtoonChapterInfo(webtoonChapter);
+
+        return chapterInfo;
+    }
+
+    private WebtoonChapterInfo webtoonChapterToWebtoonChapterInfo(WebtoonChapter webtoonChapter){
+        WebtoonChapterInfo build = WebtoonChapterInfo.builder()
+            .id(webtoonChapter.getId())
+            .webtoonName(webtoonChapter.getWebtoon().getWebtoonName())
+            .chapterName(webtoonChapter.getChapterName())
+            .chapterCount(webtoonChapter.getChapterCount())
+            .webtoonImgs(webtoonChapter.getWebtoonImgAsStringList())
+            .build();
+        return build;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,5 +24,8 @@ spring:
     open-in-view: false
   jwt:
     secret: E73TUQAxc5QLtunXK2ShWlSg1mJxP5Ikb2VhC
+  redis:
+    host: localhost
+    port: 6379
   profiles:
     include: aws


### PR DESCRIPTION
### 변경사항
** AS-IS **
- gradle에 redis 추가
- ErrorCode 추가
- Redis 설정들 추가
- 웹툰 목록 가져오기, 웹툰 리스트 가져오기, 웹툰 챕터 상세내용 가져오기 추가
- 조회수 증가 추가
** TO-BE **
- 대글, 대댓글 기능 추가
### 테스트
- [ ] 테스트 코드
- [x] API 테스트

- - -
- 조회수 기능의 경우 db에 바로 적용하는 것이 아닌 redis에 저장후에 일정 시간 뒤에 db에 저장하려고 합니다. 따라서 spring batch를 구현하면서 db에 저장하는 기능을 넣으려 합니다.
- redis에 조회수 카운팅 시에는 ip주소를 통해서 중복 계수가 되지 않도록 했습니다.

