### PR TITLE
조회수 기능 수정 및 웹툰 챕터 페이징 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compileOnly 'org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/webtoon/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/webtoon/global/exception/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
     FAIL_TO_UPLOAD_FILE(HttpStatus.BAD_REQUEST,"파일 업로드에 실패했습니다."),
     DENIED_ACCESS_PERMISSION(HttpStatus.BAD_REQUEST,"접근이 거부되었습니다."),
     EXISTS_WEBTOONNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 웹툰 이름입니다."),
-    NO_EXISTS_WEBTOONCHAPTER(HttpStatus.BAD_REQUEST,"존재하지 않는 웹툰 챕터입니다.");
+    NO_EXISTS_WEBTOONCHAPTER(HttpStatus.BAD_REQUEST,"존재하지 않는 웹툰 챕터입니다."),
+    NOT_FOUND_COMMENT(HttpStatus.BAD_REQUEST, "일치하는 댓글이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/src/main/java/com/example/webtoon/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/webtoon/global/exception/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
     NOT_FOUND_WEBTOON(HttpStatus.BAD_REQUEST,"일치하는 웹툰이 없습니다."),
     FAIL_TO_UPLOAD_FILE(HttpStatus.BAD_REQUEST,"파일 업로드에 실패했습니다."),
     DENIED_ACCESS_PERMISSION(HttpStatus.BAD_REQUEST,"접근이 거부되었습니다."),
-    EXISTS_WEBTOONNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 웹툰 이름입니다.");
+    EXISTS_WEBTOONNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 웹툰 이름입니다."),
+    NO_EXISTS_WEBTOONCHAPTER(HttpStatus.BAD_REQUEST,"존재하지 않는 웹툰 챕터입니다.");
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/src/main/java/com/example/webtoon/global/redis/RedisConfig.java
+++ b/src/main/java/com/example/webtoon/global/redis/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.example.webtoon.global.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/webtoon/global/redis/RedisConfig.java
+++ b/src/main/java/com/example/webtoon/global/redis/RedisConfig.java
@@ -1,5 +1,7 @@
 package com.example.webtoon.global.redis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,10 +9,12 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories
+@RequiredArgsConstructor
 public class RedisConfig {
     @Value("${spring.redis.host}")
     private String host;
@@ -18,16 +22,18 @@ public class RedisConfig {
     @Value("${spring.redis.port}")
     private int port;
 
+    private final ObjectMapper objectMapper;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+    public RedisTemplate<Object, Object> redisTemplate() {
+        RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
     }

--- a/src/main/java/com/example/webtoon/global/redis/RedisDao.java
+++ b/src/main/java/com/example/webtoon/global/redis/RedisDao.java
@@ -1,8 +1,6 @@
 package com.example.webtoon.global.redis;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -26,11 +24,7 @@ public class RedisDao {
         return redisTemplate.opsForHash().entries(key);
     }
 
-    public Long getLongValue(Long key){
-        return Long.valueOf(Objects.requireNonNull(redisTemplate.opsForValue().get(key)).toString());
-    }
-
-    public void deleteValues(String key) {
-        redisTemplate.delete(key);
+    public void countView(Long key){
+        redisTemplate.opsForValue().increment(key);
     }
 }

--- a/src/main/java/com/example/webtoon/global/redis/RedisDao.java
+++ b/src/main/java/com/example/webtoon/global/redis/RedisDao.java
@@ -1,8 +1,8 @@
 package com.example.webtoon.global.redis;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -11,30 +11,23 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class RedisDao {
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<Object, Object> redisTemplate;
 
-    public void setValues(String key, String data) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        values.set(key, data);
+    public void setLongValue(Long key, Long data){
+        ValueOperations<Object, Object> value = redisTemplate.opsForValue();
+        value.set(key,data);
     }
 
-    public void setValuesList(String key, String data) {
-        redisTemplate.opsForList().rightPushAll(key,data);
+    public void setValuesHash(String key, String hashkey, Long data) {
+        redisTemplate.opsForHash().put(key,hashkey,data);
     }
 
-    public List<String> getValuesList(String key) {
-        Long len = redisTemplate.opsForList().size(key);
-        return len == 0 ? new ArrayList<>() : redisTemplate.opsForList().range(key, 0, len-1);
+    public Map<Object, Object> getValuesHash(String key) {
+        return redisTemplate.opsForHash().entries(key);
     }
 
-    public void setValues(String key, String data, Duration duration) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        values.set(key, data, duration);
-    }
-
-    public String getValues(String key) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        return values.get(key);
+    public Long getLongValue(Long key){
+        return Long.valueOf(Objects.requireNonNull(redisTemplate.opsForValue().get(key)).toString());
     }
 
     public void deleteValues(String key) {

--- a/src/main/java/com/example/webtoon/global/redis/RedisDao.java
+++ b/src/main/java/com/example/webtoon/global/redis/RedisDao.java
@@ -1,0 +1,43 @@
+package com.example.webtoon.global.redis;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisDao {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void setValues(String key, String data) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data);
+    }
+
+    public void setValuesList(String key, String data) {
+        redisTemplate.opsForList().rightPushAll(key,data);
+    }
+
+    public List<String> getValuesList(String key) {
+        Long len = redisTemplate.opsForList().size(key);
+        return len == 0 ? new ArrayList<>() : redisTemplate.opsForList().range(key, 0, len-1);
+    }
+
+    public void setValues(String key, String data, Duration duration) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    public String getValues(String key) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/example/webtoon/global/redis/RestTemplateConfig.java
+++ b/src/main/java/com/example/webtoon/global/redis/RestTemplateConfig.java
@@ -1,0 +1,26 @@
+package com.example.webtoon.global.redis;
+
+import java.nio.charset.StandardCharsets;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+            .requestFactory(
+                () -> new BufferingClientHttpRequestFactory(
+                    new SimpleClientHttpRequestFactory()
+                )
+            ).additionalMessageConverters(
+                new StringHttpMessageConverter(
+                    StandardCharsets.UTF_8
+                )).build();
+    }
+}

--- a/src/main/java/com/example/webtoon/user/security/SecurityConfig.java
+++ b/src/main/java/com/example/webtoon/user/security/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .authorizeHttpRequests()
-            .antMatchers("/**/auth/**").permitAll()
+            .antMatchers("/**/auth/**","/**/webtoon/**").permitAll()
             .anyRequest().authenticated()
             .and()
             .addFilterBefore(this.authenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/webtoon/webtoon/controller/WebtoonController.java
+++ b/src/main/java/com/example/webtoon/webtoon/controller/WebtoonController.java
@@ -1,5 +1,8 @@
 package com.example.webtoon.webtoon.controller;
 
+import com.example.webtoon.webtoon.domain.dto.CommentDto;
+import com.example.webtoon.webtoon.domain.dto.CreateCommentRequest;
+import com.example.webtoon.webtoon.domain.dto.UpdateComentRequest;
 import com.example.webtoon.webtoon.domain.dto.WebtoonChapterInfo;
 import com.example.webtoon.webtoon.domain.dto.WebtoonDto;
 import com.example.webtoon.webtoon.domain.dto.WebtoonInfo;
@@ -15,6 +18,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -57,5 +62,51 @@ public class WebtoonController {
         WebtoonChapterInfo webtoonChapter = webtoonService
             .getWebtoonChapter(id, ipAddress);
         return ResponseEntity.ok(webtoonChapter);
+    }
+
+    @Transactional
+    @GetMapping("/comments-all")
+    public ResponseEntity<List<CommentDto>> getAllComments(@RequestParam Long webtoonChapterId){
+        List<CommentDto> allComments = webtoonService.getAllComments(webtoonChapterId);
+        return ResponseEntity.ok(allComments);
+    }
+
+    @Transactional
+    @GetMapping("/comment-children")
+    public ResponseEntity<List<CommentDto>> getChildrenComments(@RequestParam Long commentId){
+        List<CommentDto> childrenComments = webtoonService.getChildrenComments(commentId);
+        return ResponseEntity.ok(childrenComments);
+    }
+
+    @PostMapping("/addComment")
+    public ResponseEntity<String> createComment(@RequestBody CreateCommentRequest request){
+        webtoonService.createComment(request);
+        return ResponseEntity.ok("Success");
+    }
+
+    @PostMapping("/modifyComment")
+    public ResponseEntity<String> modifyComment(@RequestBody UpdateComentRequest request){
+        webtoonService.updateComment(request);
+        return ResponseEntity.ok("Success");
+    }
+
+    @PostMapping("/deleteComment")
+    public ResponseEntity<String> deleteComment(@RequestParam Long userId
+        , @RequestParam Long commentId){
+        webtoonService.deleteComment(userId,commentId);
+        return ResponseEntity.ok("Success");
+    }
+    @PostMapping("/StarScore")
+    public ResponseEntity<String> giveStarScore(@RequestParam Long webtoonChapterId,
+        @RequestParam Long userId,@RequestParam Long starScore){
+        webtoonService.giveStarScore(webtoonChapterId,userId,starScore);
+        return ResponseEntity.ok("Success");
+    }
+
+    @PostMapping("/recommend")
+    public ResponseEntity<String> giveRecommend(@RequestParam Long commentId
+        , @RequestParam Long userId, boolean recommendType){
+        webtoonService.giveRecommend(commentId,userId,recommendType);
+        return ResponseEntity.ok("Success");
     }
 }

--- a/src/main/java/com/example/webtoon/webtoon/controller/WebtoonController.java
+++ b/src/main/java/com/example/webtoon/webtoon/controller/WebtoonController.java
@@ -4,12 +4,14 @@ import com.example.webtoon.webtoon.domain.dto.WebtoonChapterInfo;
 import com.example.webtoon.webtoon.domain.dto.WebtoonDto;
 import com.example.webtoon.webtoon.domain.dto.WebtoonInfo;
 import com.example.webtoon.webtoon.domain.model.Webtoon;
-import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
 import com.example.webtoon.webtoon.service.WebtoonService;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,8 +43,10 @@ public class WebtoonController {
 
     @Transactional
     @GetMapping("/list")
-    public ResponseEntity<List<WebtoonChapterInfo>> getWebtoonChapters(@RequestParam Long webtoonId){
-        List<WebtoonChapterInfo> webtoonChapters = webtoonService.getWebtoonChapters(webtoonId);
+    public ResponseEntity<Page<WebtoonChapterInfo>> getWebtoonChapters(@RequestParam Long webtoonId
+    , @PageableDefault(size = 10) Pageable pageable){
+        Page<WebtoonChapterInfo> webtoonChapters = webtoonService
+            .getWebtoonChapters(webtoonId,pageable);
         return ResponseEntity.ok(webtoonChapters);
     }
 
@@ -50,7 +54,8 @@ public class WebtoonController {
     @GetMapping("/detail")
     public ResponseEntity<WebtoonChapterInfo> getWebtoon(HttpServletRequest request, @RequestParam Long id){
         String ipAddress = request.getRemoteAddr();
-        WebtoonChapterInfo webtoonChapter = webtoonService.getWebtoonChapter(id, ipAddress);
+        WebtoonChapterInfo webtoonChapter = webtoonService
+            .getWebtoonChapter(id, ipAddress);
         return ResponseEntity.ok(webtoonChapter);
     }
 }

--- a/src/main/java/com/example/webtoon/webtoon/controller/WebtoonController.java
+++ b/src/main/java/com/example/webtoon/webtoon/controller/WebtoonController.java
@@ -1,8 +1,13 @@
 package com.example.webtoon.webtoon.controller;
 
+import com.example.webtoon.webtoon.domain.dto.WebtoonChapterInfo;
 import com.example.webtoon.webtoon.domain.dto.WebtoonDto;
+import com.example.webtoon.webtoon.domain.dto.WebtoonInfo;
 import com.example.webtoon.webtoon.domain.model.Webtoon;
+import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
 import com.example.webtoon.webtoon.service.WebtoonService;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -25,5 +30,27 @@ public class WebtoonController {
     public ResponseEntity<WebtoonDto> searchWebtoon(@RequestParam Long id){
         Webtoon webtoon = webtoonService.getWebtoon(id);
         return ResponseEntity.ok(WebtoonDto.from(webtoon));
+    }
+
+    @Transactional
+    @GetMapping("/index")
+    public ResponseEntity<List<WebtoonInfo>> getAllWebtoons(){
+        List<WebtoonInfo> allWebtoons = webtoonService.getAllWebtoons();
+        return ResponseEntity.ok(allWebtoons);
+    }
+
+    @Transactional
+    @GetMapping("/list")
+    public ResponseEntity<List<WebtoonChapterInfo>> getWebtoonChapters(@RequestParam Long webtoonId){
+        List<WebtoonChapterInfo> webtoonChapters = webtoonService.getWebtoonChapters(webtoonId);
+        return ResponseEntity.ok(webtoonChapters);
+    }
+
+    @Transactional
+    @GetMapping("/detail")
+    public ResponseEntity<WebtoonChapterInfo> getWebtoon(HttpServletRequest request, @RequestParam Long id){
+        String ipAddress = request.getRemoteAddr();
+        WebtoonChapterInfo webtoonChapter = webtoonService.getWebtoonChapter(id, ipAddress);
+        return ResponseEntity.ok(webtoonChapter);
     }
 }

--- a/src/main/java/com/example/webtoon/webtoon/domain/dto/ChapterSearchDto.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/dto/ChapterSearchDto.java
@@ -1,0 +1,18 @@
+package com.example.webtoon.webtoon.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChapterSearchDto {
+    private int page;             // 현재 페이지 번호
+    private int recordSize;       // 페이지당 출력할 데이터 개수
+    private int pageSize;         // 화면 하단에 출력할 페이지 사이즈
+
+    public ChapterSearchDto() {
+        this.page = 1;
+        this.recordSize = 10;
+        this.pageSize = 10;
+    }
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/dto/CommentDto.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/dto/CommentDto.java
@@ -1,0 +1,28 @@
+package com.example.webtoon.webtoon.domain.dto;
+
+import com.example.webtoon.webtoon.domain.model.Comment;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommentDto {
+    private Long id;
+    private String nickname;
+    private String content;
+    private Integer recommend;
+    private Integer notRecommend;
+    private LocalDateTime dateTime;
+
+    public static CommentDto of(Comment comment, Integer recommend, Integer notRecommend){
+        return CommentDto.builder()
+            .id(comment.getId())
+            .nickname(comment.getWriter().getNickname())
+            .content(comment.getContent())
+            .recommend(recommend)
+            .notRecommend(notRecommend)
+            .dateTime(comment.getModifiedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/dto/CreateCommentRequest.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/dto/CreateCommentRequest.java
@@ -1,0 +1,15 @@
+package com.example.webtoon.webtoon.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CreateCommentRequest {
+    private Long userId;
+    private Long webtoonChapterId;
+    private Long commentId;
+    private String content;
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/dto/UpdateComentRequest.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/dto/UpdateComentRequest.java
@@ -1,0 +1,14 @@
+package com.example.webtoon.webtoon.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UpdateComentRequest {
+    private Long commentId;
+    private Long userId;
+    private String content;
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonChapterInfo.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonChapterInfo.java
@@ -1,5 +1,6 @@
 package com.example.webtoon.webtoon.domain.dto;
 
+import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,4 +15,14 @@ public class WebtoonChapterInfo {
     private String chapterName;
     private Integer chapterCount;
     private List<String> webtoonImgs;
+
+    public static WebtoonChapterInfo of(WebtoonChapter webtoonChapter){
+        return WebtoonChapterInfo.builder()
+            .id(webtoonChapter.getId())
+            .webtoonName(webtoonChapter.getWebtoon().getWebtoonName())
+            .chapterName(webtoonChapter.getChapterName())
+            .chapterCount(webtoonChapter.getChapterCount())
+            .webtoonImgs(webtoonChapter.getWebtoonImgAsStringList())
+            .build();
+    }
 }

--- a/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonChapterInfo.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonChapterInfo.java
@@ -1,0 +1,17 @@
+package com.example.webtoon.webtoon.domain.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class WebtoonChapterInfo {
+    private Long id;
+    private String webtoonName;
+    private String chapterName;
+    private Integer chapterCount;
+    private List<String> webtoonImgs;
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonInfo.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonInfo.java
@@ -1,5 +1,6 @@
 package com.example.webtoon.webtoon.domain.dto;
 
+import com.example.webtoon.webtoon.domain.model.Webtoon;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,4 +16,14 @@ public class WebtoonInfo {
     private String uploadDay;
     private Long viewCount;
     private Double starScore;
+
+    public static WebtoonInfo of(Webtoon webtoon){
+        return WebtoonInfo.builder()
+            .id(webtoon.getId())
+            .author(webtoon.getAuthor().getNickname())
+            .hashtags(webtoon.getHashtagsAsStringList())
+            .viewCount(webtoon.getViewCount())
+            .starScore(webtoon.getStarScore())
+            .build();
+    }
 }

--- a/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonInfo.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/dto/WebtoonInfo.java
@@ -1,0 +1,18 @@
+package com.example.webtoon.webtoon.domain.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class WebtoonInfo {
+    private Long id;
+    private String author;
+    private List<String> hashtags;
+    private String uploadDay;
+    private Long viewCount;
+    private Double starScore;
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/model/Comment.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/model/Comment.java
@@ -1,0 +1,42 @@
+package com.example.webtoon.webtoon.domain.model;
+
+import com.example.webtoon.global.domain.BaseEntity;
+import com.example.webtoon.user.domain.model.User;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Comment extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    private User writer;
+    @ManyToOne
+    private WebtoonChapter webtoonChapter;
+    @ManyToOne
+    private Comment parent;
+    private String content;
+    private Boolean isDeleted;
+
+    public static Comment of(User user, WebtoonChapter webtoonChapter){
+        return Comment.builder()
+            .writer(user)
+            .webtoonChapter(webtoonChapter)
+            .isDeleted(false).build();
+    }
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/model/Recommend.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/model/Recommend.java
@@ -1,0 +1,31 @@
+package com.example.webtoon.webtoon.domain.model;
+
+import com.example.webtoon.user.domain.model.User;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Recommend {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    private Comment comment;
+    @ManyToOne
+    private User user;
+    private Boolean recommendType;
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/model/StarScore.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/model/StarScore.java
@@ -1,0 +1,31 @@
+package com.example.webtoon.webtoon.domain.model;
+
+import com.example.webtoon.user.domain.model.User;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class StarScore {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    private User user;
+    @ManyToOne
+    private WebtoonChapter webtoonChapter;
+    private Long starscore;
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/model/WebtoonChapter.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/model/WebtoonChapter.java
@@ -3,6 +3,7 @@ package com.example.webtoon.webtoon.domain.model;
 import com.example.webtoon.global.domain.BaseEntity;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -34,4 +35,8 @@ public class WebtoonChapter extends BaseEntity {
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "WEBTOONCHAPTER_ID")
     private List<WebtoonImg> webtoonImgs = new ArrayList<>();
+
+    public List<String> getWebtoonImgAsStringList(){
+        return webtoonImgs.stream().map(WebtoonImg::getImgUrl).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/example/webtoon/webtoon/domain/model/WebtoonImg.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/model/WebtoonImg.java
@@ -17,6 +17,8 @@ public class WebtoonImg extends BaseEntity {
     private Long id;
     private String imgUrl;
 
+    public String getImgUrl(){return imgUrl;};
+
     private WebtoonImg(String url){
         this.imgUrl = url;
     }

--- a/src/main/java/com/example/webtoon/webtoon/domain/repository/CommentRepository.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/repository/CommentRepository.java
@@ -1,0 +1,15 @@
+package com.example.webtoon.webtoon.domain.repository;
+
+import com.example.webtoon.webtoon.domain.model.Comment;
+import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByParentAndIsDeletedIsFalseAndWebtoonChapter(
+        Comment comment, WebtoonChapter webtoonChapter);
+    List<Comment> findByParentAndIsDeletedFalse(Comment comment);
+
+    Optional<Comment> findByIdAndIsDeletedFalse(Long id);
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/repository/RecommendRepository.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/repository/RecommendRepository.java
@@ -1,0 +1,13 @@
+package com.example.webtoon.webtoon.domain.repository;
+
+import com.example.webtoon.user.domain.model.User;
+import com.example.webtoon.webtoon.domain.model.Comment;
+import com.example.webtoon.webtoon.domain.model.Recommend;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecommendRepository extends JpaRepository<Recommend,Long> {
+    Integer countByCommentAndRecommendTypeIsTrue(Comment comment);
+    Integer countByCommentAndRecommendTypeIsFalse(Comment comment);
+    boolean existsByCommentAndUser(Comment comment, User user);
+    Recommend findByCommentAndUser(Comment comment, User user);
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/repository/StarScpreRepository.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/repository/StarScpreRepository.java
@@ -1,0 +1,12 @@
+package com.example.webtoon.webtoon.domain.repository;
+
+import com.example.webtoon.user.domain.model.User;
+import com.example.webtoon.webtoon.domain.model.StarScore;
+import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StarScpreRepository extends JpaRepository<StarScore, Long> {
+    boolean existsByUserAndWebtoonChapter(User user, WebtoonChapter webtoonChapter);
+    Optional<StarScore> findByUserAndWebtoonChapter(User user, WebtoonChapter webtoonChapter);
+}

--- a/src/main/java/com/example/webtoon/webtoon/domain/repository/WebtoonChapterRepository.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/repository/WebtoonChapterRepository.java
@@ -2,10 +2,11 @@ package com.example.webtoon.webtoon.domain.repository;
 
 import com.example.webtoon.webtoon.domain.model.Webtoon;
 import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WebtoonChapterRepository extends JpaRepository<WebtoonChapter,Long> {
     Integer countByWebtoon(Webtoon webtoon);
-    List<WebtoonChapter> findAllByWebtoon(Webtoon webtoon);
+    Page<WebtoonChapter> findAllByWebtoon(Webtoon webtoon, Pageable pageable);
 }

--- a/src/main/java/com/example/webtoon/webtoon/domain/repository/WebtoonChapterRepository.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/repository/WebtoonChapterRepository.java
@@ -2,8 +2,10 @@ package com.example.webtoon.webtoon.domain.repository;
 
 import com.example.webtoon.webtoon.domain.model.Webtoon;
 import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WebtoonChapterRepository extends JpaRepository<WebtoonChapter,Long> {
     Integer countByWebtoon(Webtoon webtoon);
+    List<WebtoonChapter> findAllByWebtoon(Webtoon webtoon);
 }

--- a/src/main/java/com/example/webtoon/webtoon/domain/repository/WebtoonRepository.java
+++ b/src/main/java/com/example/webtoon/webtoon/domain/repository/WebtoonRepository.java
@@ -1,6 +1,7 @@
 package com.example.webtoon.webtoon.domain.repository;
 
 import com.example.webtoon.webtoon.domain.model.Webtoon;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/example/webtoon/webtoon/service/WebtoonManageService.java
+++ b/src/main/java/com/example/webtoon/webtoon/service/WebtoonManageService.java
@@ -53,8 +53,7 @@ public class WebtoonManageService {
                 .viewCount(0L)
                 .starScore(0.0)
                 .build());
-        String redisKey = String.valueOf(webtoon.getId());
-        redisDao.setValues(redisKey, "0");
+        redisDao.setLongValue(webtoon.getId(), 0L);
         return webtoon;
     }
 

--- a/src/main/java/com/example/webtoon/webtoon/service/WebtoonManageService.java
+++ b/src/main/java/com/example/webtoon/webtoon/service/WebtoonManageService.java
@@ -4,6 +4,7 @@ import com.example.webtoon.global.exception.ErrorCode;
 import com.example.webtoon.global.exception.GlobalException;
 import com.example.webtoon.global.fileUpload.StoreFileClient;
 import com.example.webtoon.global.fileUpload.UploadFile;
+import com.example.webtoon.global.redis.RedisDao;
 import com.example.webtoon.user.domain.model.User;
 import com.example.webtoon.user.domain.repository.UserRepository;
 import com.example.webtoon.webtoon.domain.dto.CreateWebtoonRequest;
@@ -30,6 +31,7 @@ public class WebtoonManageService {
     private final WebtoonRepository webtoonRepository;
     private final WebtoonChapterRepository webtoonChapterRepository;
     private final StoreFileClient storeFileClient;
+    private final RedisDao redisDao;
 
     @Transactional
     public Webtoon createWebtoon(CreateWebtoonRequest request, String email){
@@ -42,7 +44,7 @@ public class WebtoonManageService {
         Set<WebtoonHashtag> hashtags = request.getHashtags().stream()
             .map(WebtoonHashtag::of)
             .collect(Collectors.toSet());
-        return webtoonRepository.save(
+        Webtoon webtoon = webtoonRepository.save(
             Webtoon.builder()
                 .author(user)
                 .hashtags(hashtags)
@@ -51,6 +53,9 @@ public class WebtoonManageService {
                 .viewCount(0L)
                 .starScore(0.0)
                 .build());
+        String redisKey = String.valueOf(webtoon.getId());
+        redisDao.setValues(redisKey, "0");
+        return webtoon;
     }
 
     @Transactional

--- a/src/main/java/com/example/webtoon/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/example/webtoon/webtoon/service/WebtoonService.java
@@ -2,8 +2,15 @@ package com.example.webtoon.webtoon.service;
 
 import com.example.webtoon.global.exception.ErrorCode;
 import com.example.webtoon.global.exception.GlobalException;
+import com.example.webtoon.global.redis.RedisDao;
+import com.example.webtoon.webtoon.domain.dto.WebtoonChapterInfo;
+import com.example.webtoon.webtoon.domain.dto.WebtoonInfo;
 import com.example.webtoon.webtoon.domain.model.Webtoon;
+import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
+import com.example.webtoon.webtoon.domain.repository.WebtoonChapterRepository;
 import com.example.webtoon.webtoon.domain.repository.WebtoonRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,11 +20,69 @@ import org.springframework.transaction.annotation.Transactional;
 public class WebtoonService {
 
     private final WebtoonRepository webtoonRepository;
+    private final WebtoonChapterRepository webtoonChapterRepository;
+    private final RedisDao redisDao;
 
     @Transactional
     public Webtoon getWebtoon(Long id){
         Webtoon webtoon =  this.webtoonRepository.findById(id)
             .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_WEBTOON));
         return webtoon;
+    }
+
+    public List<WebtoonInfo> getAllWebtoons(){
+        List<Webtoon> webtoonList = this.webtoonRepository.findAll();
+        List<WebtoonInfo> webtoonInfoList = new ArrayList<>();
+        for(Webtoon w : webtoonList){
+            WebtoonInfo webtoonInfo = WebtoonInfo.builder()
+                .id(w.getId())
+                .author(w.getAuthor().getNickname())
+                .hashtags(w.getHashtagsAsStringList())
+                .viewCount(w.getViewCount())
+                .starScore(w.getStarScore())
+                .build();
+            webtoonInfoList.add(webtoonInfo);
+        }
+        return webtoonInfoList;
+    }
+
+    public List<WebtoonChapterInfo> getWebtoonChapters(Long webtoonId){
+        Webtoon webtoon =  this.webtoonRepository.findById(webtoonId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_WEBTOON));
+        List<WebtoonChapter> chapterList = this.webtoonChapterRepository.findAllByWebtoon(webtoon);
+        List<WebtoonChapterInfo> webtoonChapterInfoList = new ArrayList<>();
+        for(WebtoonChapter c : chapterList){
+            WebtoonChapterInfo chapterInfo = webtoonChapterToWebtoonChapterInfo(c);
+            webtoonChapterInfoList.add(chapterInfo);
+        }
+        return webtoonChapterInfoList;
+    }
+
+    public WebtoonChapterInfo getWebtoonChapter(Long chapterId, String ipAddress){
+        WebtoonChapter webtoonChapter = this.webtoonChapterRepository.findById(chapterId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NO_EXISTS_WEBTOONCHAPTER));
+
+        String redisKey = String.valueOf(webtoonChapter.getWebtoon().getId());
+        String values = redisDao.getValues(redisKey);
+        if(!redisDao.getValuesList(ipAddress).contains(redisKey)){
+            Long views = Long.parseLong(values);
+            redisDao.setValuesList(ipAddress, redisKey);
+            views += 1;
+            redisDao.setValues(redisKey, String.valueOf(views));
+        }
+        WebtoonChapterInfo chapterInfo = webtoonChapterToWebtoonChapterInfo(webtoonChapter);
+
+        return chapterInfo;
+    }
+
+    private WebtoonChapterInfo webtoonChapterToWebtoonChapterInfo(WebtoonChapter webtoonChapter){
+        WebtoonChapterInfo build = WebtoonChapterInfo.builder()
+            .id(webtoonChapter.getId())
+            .webtoonName(webtoonChapter.getWebtoon().getWebtoonName())
+            .chapterName(webtoonChapter.getChapterName())
+            .chapterCount(webtoonChapter.getChapterCount())
+            .webtoonImgs(webtoonChapter.getWebtoonImgAsStringList())
+            .build();
+        return build;
     }
 }

--- a/src/main/java/com/example/webtoon/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/example/webtoon/webtoon/service/WebtoonService.java
@@ -3,13 +3,25 @@ package com.example.webtoon.webtoon.service;
 import com.example.webtoon.global.exception.ErrorCode;
 import com.example.webtoon.global.exception.GlobalException;
 import com.example.webtoon.global.redis.RedisDao;
+import com.example.webtoon.user.domain.model.User;
+import com.example.webtoon.user.domain.repository.UserRepository;
+import com.example.webtoon.webtoon.domain.dto.CommentDto;
+import com.example.webtoon.webtoon.domain.dto.CreateCommentRequest;
+import com.example.webtoon.webtoon.domain.dto.UpdateComentRequest;
 import com.example.webtoon.webtoon.domain.dto.WebtoonChapterInfo;
 import com.example.webtoon.webtoon.domain.dto.WebtoonInfo;
+import com.example.webtoon.webtoon.domain.model.Comment;
+import com.example.webtoon.webtoon.domain.model.Recommend;
+import com.example.webtoon.webtoon.domain.model.StarScore;
 import com.example.webtoon.webtoon.domain.model.Webtoon;
 import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
+import com.example.webtoon.webtoon.domain.repository.CommentRepository;
+import com.example.webtoon.webtoon.domain.repository.RecommendRepository;
+import com.example.webtoon.webtoon.domain.repository.StarScpreRepository;
 import com.example.webtoon.webtoon.domain.repository.WebtoonChapterRepository;
 import com.example.webtoon.webtoon.domain.repository.WebtoonRepository;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -25,6 +37,10 @@ public class WebtoonService {
     private final WebtoonRepository webtoonRepository;
     private final WebtoonChapterRepository webtoonChapterRepository;
     private final RedisDao redisDao;
+    private final CommentRepository commentRepository;
+    private final RecommendRepository recommendRepository;
+    private final UserRepository userRepository;
+    private final StarScpreRepository starScpreRepository;
 
     @Transactional
     public Webtoon getWebtoon(Long id){
@@ -58,5 +74,107 @@ public class WebtoonService {
         }
 
         return WebtoonChapterInfo.of(webtoonChapter);
+    }
+
+    public List<CommentDto> getAllComments(Long webtoonChapterId){
+        WebtoonChapter webtoonChapter = this.webtoonChapterRepository.findById(webtoonChapterId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NO_EXISTS_WEBTOONCHAPTER));
+        List<Comment> comments = this.commentRepository
+            .findByParentAndIsDeletedIsFalseAndWebtoonChapter(null, webtoonChapter);
+        return comments.stream().map(c -> CommentDto.of(
+            c, this.recommendRepository.countByCommentAndRecommendTypeIsTrue(c)
+                    , this.recommendRepository.countByCommentAndRecommendTypeIsFalse(c))).toList();
+    }
+
+    public List<CommentDto> getChildrenComments(Long parentId){
+        Comment parent = this.commentRepository.findByIdAndIsDeletedFalse(parentId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_COMMENT));
+        List<Comment> comments = this.commentRepository.findByParentAndIsDeletedFalse(parent);
+        return comments.stream().map(c -> CommentDto.of(
+            c, this.recommendRepository.countByCommentAndRecommendTypeIsTrue(c)
+            , this.recommendRepository.countByCommentAndRecommendTypeIsFalse(c))).toList();
+    }
+
+    @Transactional
+    public void createComment(CreateCommentRequest request){
+        User user = this.userRepository.findById(request.getUserId())
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_USER));
+        WebtoonChapter webtoonChapter = this.webtoonChapterRepository.findById(
+                request.getWebtoonChapterId())
+            .orElseThrow(() -> new GlobalException(ErrorCode.NO_EXISTS_WEBTOONCHAPTER));
+        Comment comment = Comment.of(user, webtoonChapter);
+        if(request.getCommentId() != null){
+            Comment parent = this.commentRepository.findById(request.getCommentId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_COMMENT));
+            comment.setParent(parent);
+        }
+        comment.setContent(request.getContent());
+        this.commentRepository.save(comment);
+    }
+
+    @Transactional
+    public void updateComment(UpdateComentRequest request){
+        Comment comment = this.commentRepository.findById(request.getCommentId())
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_COMMENT));
+        User user = this.userRepository.findById(request.getUserId())
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_USER));
+        if(comment.getWriter() != user){
+            throw new GlobalException(ErrorCode.DENIED_ACCESS_PERMISSION);
+        }
+        comment.setContent(request.getContent());
+    }
+
+    @Transactional
+    public void deleteComment(Long userId, Long commentId){
+        Comment comment = this.commentRepository.findById(commentId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_COMMENT));
+        User user = this.userRepository.findById(userId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_USER));
+        if(comment.getWriter() != user){
+            throw new GlobalException(ErrorCode.DENIED_ACCESS_PERMISSION);
+        }
+        comment.setIsDeleted(true);
+    }
+
+    @Transactional
+    public void giveStarScore(Long webtoonChapterId, Long userId, Long starScore){
+        WebtoonChapter webtoonChapter = this.webtoonChapterRepository.findById(webtoonChapterId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NO_EXISTS_WEBTOONCHAPTER));
+        User user = this.userRepository.findById(userId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_USER));
+        boolean exists = this.starScpreRepository.existsByUserAndWebtoonChapter(user, webtoonChapter);
+        if(exists){
+            StarScore star = this.starScpreRepository.findByUserAndWebtoonChapter(
+                user, webtoonChapter)
+                .orElseThrow(() -> new GlobalException(ErrorCode.DENIED_ACCESS_PERMISSION));
+            star.setStarscore(starScore);
+        }else{
+            this.starScpreRepository.save(StarScore.builder()
+                .user(user)
+                .webtoonChapter(webtoonChapter)
+                .starscore(starScore)
+                .build());
+        }
+    }
+
+    @Transactional
+    public void giveRecommend(Long commentId, Long userId, boolean recommendType){
+        Comment comment = this.commentRepository.findById(commentId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_COMMENT));
+        User user = this.userRepository.findById(userId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_USER));
+        boolean exists = this.recommendRepository.existsByCommentAndUser(comment, user);
+        if(exists){
+            Recommend recommend = this.recommendRepository.findByCommentAndUser(comment, user);
+            if(recommendType != recommend.getRecommendType())
+                recommend.setRecommendType(recommendType);
+        }else{
+            this.recommendRepository.save(
+                Recommend.builder()
+                    .comment(comment)
+                    .user(user)
+                    .recommendType(recommendType).build()
+            );
+        }
     }
 }

--- a/src/main/java/com/example/webtoon/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/example/webtoon/webtoon/service/WebtoonService.java
@@ -9,9 +9,12 @@ import com.example.webtoon.webtoon.domain.model.Webtoon;
 import com.example.webtoon.webtoon.domain.model.WebtoonChapter;
 import com.example.webtoon.webtoon.domain.repository.WebtoonChapterRepository;
 import com.example.webtoon.webtoon.domain.repository.WebtoonRepository;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,64 +28,53 @@ public class WebtoonService {
 
     @Transactional
     public Webtoon getWebtoon(Long id){
-        Webtoon webtoon =  this.webtoonRepository.findById(id)
+        return this.webtoonRepository.findById(id)
             .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_WEBTOON));
-        return webtoon;
     }
 
     public List<WebtoonInfo> getAllWebtoons(){
         List<Webtoon> webtoonList = this.webtoonRepository.findAll();
-        List<WebtoonInfo> webtoonInfoList = new ArrayList<>();
-        for(Webtoon w : webtoonList){
-            WebtoonInfo webtoonInfo = WebtoonInfo.builder()
-                .id(w.getId())
-                .author(w.getAuthor().getNickname())
-                .hashtags(w.getHashtagsAsStringList())
-                .viewCount(w.getViewCount())
-                .starScore(w.getStarScore())
-                .build();
-            webtoonInfoList.add(webtoonInfo);
-        }
-        return webtoonInfoList;
+        return webtoonList.stream().map(w -> WebtoonInfo.builder()
+            .id(w.getId())
+            .author(w.getAuthor().getNickname())
+            .hashtags(w.getHashtagsAsStringList())
+            .viewCount(w.getViewCount())
+            .starScore(w.getStarScore())
+            .build()).collect(Collectors.toList());
     }
 
-    public List<WebtoonChapterInfo> getWebtoonChapters(Long webtoonId){
+    public Page<WebtoonChapterInfo> getWebtoonChapters(Long webtoonId, Pageable pageable){
         Webtoon webtoon =  this.webtoonRepository.findById(webtoonId)
             .orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_WEBTOON));
-        List<WebtoonChapter> chapterList = this.webtoonChapterRepository.findAllByWebtoon(webtoon);
-        List<WebtoonChapterInfo> webtoonChapterInfoList = new ArrayList<>();
-        for(WebtoonChapter c : chapterList){
-            WebtoonChapterInfo chapterInfo = webtoonChapterToWebtoonChapterInfo(c);
-            webtoonChapterInfoList.add(chapterInfo);
-        }
-        return webtoonChapterInfoList;
+        Page<WebtoonChapter> chapterList = this.webtoonChapterRepository
+            .findAllByWebtoon(webtoon, pageable);
+        List<WebtoonChapterInfo> chapterInfoList = chapterList.stream().map(
+            this::webtoonChapterToWebtoonChapterInfo).collect(Collectors.toList());
+        return new PageImpl<>(chapterInfoList,pageable,chapterList.getTotalElements());
     }
 
     public WebtoonChapterInfo getWebtoonChapter(Long chapterId, String ipAddress){
         WebtoonChapter webtoonChapter = this.webtoonChapterRepository.findById(chapterId)
             .orElseThrow(() -> new GlobalException(ErrorCode.NO_EXISTS_WEBTOONCHAPTER));
 
-        String redisKey = String.valueOf(webtoonChapter.getWebtoon().getId());
-        String values = redisDao.getValues(redisKey);
-        if(!redisDao.getValuesList(ipAddress).contains(redisKey)){
-            Long views = Long.parseLong(values);
-            redisDao.setValuesList(ipAddress, redisKey);
+        Long redisKey = webtoonChapter.getWebtoon().getId();
+        Long views = redisDao.getLongValue(redisKey);
+        if(!redisDao.getValuesHash("viewCount").containsKey(ipAddress)){
+            redisDao.setValuesHash("viewCount",ipAddress, redisKey);
             views += 1;
-            redisDao.setValues(redisKey, String.valueOf(views));
+            redisDao.setLongValue(redisKey, views);
         }
-        WebtoonChapterInfo chapterInfo = webtoonChapterToWebtoonChapterInfo(webtoonChapter);
 
-        return chapterInfo;
+        return webtoonChapterToWebtoonChapterInfo(webtoonChapter);
     }
 
     private WebtoonChapterInfo webtoonChapterToWebtoonChapterInfo(WebtoonChapter webtoonChapter){
-        WebtoonChapterInfo build = WebtoonChapterInfo.builder()
+        return WebtoonChapterInfo.builder()
             .id(webtoonChapter.getId())
             .webtoonName(webtoonChapter.getWebtoon().getWebtoonName())
             .chapterName(webtoonChapter.getChapterName())
             .chapterCount(webtoonChapter.getChapterCount())
             .webtoonImgs(webtoonChapter.getWebtoonImgAsStringList())
             .build();
-        return build;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,5 +24,8 @@ spring:
     open-in-view: false
   jwt:
     secret: E73TUQAxc5QLtunXK2ShWlSg1mJxP5Ikb2VhC
+  redis:
+    host: localhost
+    port: 6379
   profiles:
     include: aws


### PR DESCRIPTION
### 변경사항
** AS-IS **
- gradle에 redis 추가
- ErrorCode 추가
- Redis 설정들 추가
- 웹툰 목록 가져오기, 웹툰 리스트 가져오기, 웹툰 챕터 상세내용 가져오기 추가
- 조회수 증가 추가
- 웹툰 챕터 페이징 추가
** TO-BE **
- 대글, 대댓글 기능 추가
### 테스트
- [ ] 테스트 코드
- [x] API 테스트

- - -
- 조회수 기능의 경우 db에 바로 적용하는 것이 아닌 redis에 저장후에 일정 시간 뒤에 db에 저장하려고 합니다. 따라서 spring batch를 구현하면서 db에 저장하는 기능을 넣으려 합니다.
- redis에 조회수 카운팅 시에는 ip주소를 통해서 중복 계수가 되지 않도록 했습니다.